### PR TITLE
Feat : createVNode

### DIFF
--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,3 +1,11 @@
 export function createVNode(type, props, ...children) {
-  return {};
+  const flatChildren = children
+    .flat(Infinity)
+    .filter((child) => child || child === 0);
+
+  return {
+    type,
+    props: props || {},
+    children: flatChildren,
+  };
 }

--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -5,7 +5,7 @@ export function createVNode(type, props, ...children) {
 
   return {
     type,
-    props: props || {},
+    props: props || null,
     children: flatChildren,
   };
 }


### PR DESCRIPTION
<img width="472" alt="스크린샷 2024-12-22 오후 3 51 12" src="https://github.com/user-attachments/assets/462f217d-6a4b-47ca-98b0-7d03ade4dc68" />

## createVnode 함수 구현하기 

- `flat()`으로 평탄화할 때 재귀적으로 사용하지 않으면 1단계만 평탄화되어 그 자식 컴포넌트는 평탄화되지 않습니다 
  - flat(Infinity) 혹은 재귀적으로 호출하는 코드를 직접 작성해야합니다. 

### 평탄화 이유 
평탄화 작업을 해야하는 이유로는 다음과 같습니다. 
- 가상돔을 생성할 때, 중첩된 배열 구조로 자식 요소를 전달할 수 있습니다. 그 과정에서 자식 배열이 중첩된 상태로 남아있다면 렌더링 로직에서 자식 노드를 순회하면서 돔에 추가하는 과정이 복잡해집니다. 또한, 매번 중첩 여부를 확인이 필요하기 때문에 비효율적입니다. 

모든 자식 배열을 평탄화하여 렌더링 로직에서 모든 자식을 동일한 수준에서 다룰 수 있도록 해줍니다. 
평탄화하는 작업을 해줌으로 효율적이고 동일하게 렌더링 로직이 이를 처리할 수 있습니다. 

### falsy값을 필터링하는 이유 
- children값에서 falsy (null, undefined, false)값은 필터링합니다 (0은 제외)
  - 이 과정을 통해 불필요한 돔 생성을 방지하여 렌더링 가능한 값으로만 구성됩니다 