### PR TITLE
Feat : normalizeVNode 

### DIFF
--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,7 +1,7 @@
-export function createVNode(type, props, ...children) {
+export function createVNode(type, props = {}, ...children) {
   return {
     type,
-    props: props,
+    props,
     children: children.flat(Infinity).filter((child) => child || child === 0),
   };
 }

--- a/src/lib/createVNode.js
+++ b/src/lib/createVNode.js
@@ -1,11 +1,7 @@
 export function createVNode(type, props, ...children) {
-  const flatChildren = children
-    .flat(Infinity)
-    .filter((child) => child || child === 0);
-
   return {
     type,
-    props: props || null,
-    children: flatChildren,
+    props: props,
+    children: children.flat(Infinity).filter((child) => child || child === 0),
   };
 }

--- a/src/lib/normalizeVNode.js
+++ b/src/lib/normalizeVNode.js
@@ -1,3 +1,9 @@
 export function normalizeVNode(vNode) {
+  if (typeof vNode === "number" || typeof vNode === "string") {
+    return String(vNode);
+  }
+  if (!vNode || typeof vNode === "boolean") {
+    return "";
+  }
   return vNode;
 }

--- a/src/lib/normalizeVNode.js
+++ b/src/lib/normalizeVNode.js
@@ -2,8 +2,20 @@ export function normalizeVNode(vNode) {
   if (typeof vNode === "number" || typeof vNode === "string") {
     return String(vNode);
   }
-  if (!vNode || typeof vNode === "boolean") {
+  if (vNode === null || vNode === undefined || typeof vNode === "boolean") {
     return "";
   }
-  return vNode;
+
+  if (typeof vNode.type === "function") {
+    return normalizeVNode(
+      vNode.type({ ...vNode.props, children: vNode.children }),
+    );
+  }
+  return {
+    ...vNode,
+    children: vNode.children
+      .filter((child) => child || child === 0)
+      .map((child) => normalizeVNode(child))
+      .filter((child) => child !== ""),
+  };
 }


### PR DESCRIPTION

<img width="566" alt="image" src="https://github.com/user-attachments/assets/c5ab9a2d-2278-471f-b629-7043b6b68539" />

## normalizeVNode 구현 

- 정규화를 하는 이유 => 불필요한 값을 제거하여 일관되고 최적화된 가상 돔 트리를 만들기 위함입니다. 이를 통해 다양한 입력을 표준화하여 렌더링에 필요한 데이터를 준비할 수 있습니다. 


### 막힌 부분 
컴포넌트를 정규화하는 부분 



vNode 값에는 `type`, `props`, `children`라는 평탄화해준 값으로 들어옵니다. 
이 과정에서 들어온 값이 `type`이 함수인 경우, `children`이 함수인 경우가 있습니다. 
그 두가지 경우에 해당하는 경우, 재귀함수로 다시 정규화를 시켜주어서 테스트 요구사항을 충족시킬 수 있었습니다. 

하지만 처음 접근을 vNode자체를 재귀로 호출하고 있었어서 정상적으로 요구사항을 충족시키지 못해 오류가 발생했었습니다. 
앞으로 디버깅을 계속 진행하면서 어떤 값으로 들어오고 처리되는 지를 확인해봐야겠다는 생각을 하게되었습니다